### PR TITLE
Changing module to require a network

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
 
       # Package files into tgz
       - name: Package
-        run: tar -cvzf module.tgz *.tf *.tf.tmpl
+        run: tar -cvzf module.tgz *.tf *.tf.tmpl README.md
 
       - name: Find version
         id: version

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ __backend__.tf
 .nullstone/active-workspace.yml
 
 .terraform.lock.hcl
+
+placeholder.zip

--- a/.nullstone/module.yml
+++ b/.nullstone/module.yml
@@ -1,7 +1,7 @@
 org_name: nullstone
 name: aws-lambda-service
 friendly_name: Lambda Service
-description: Creates a lambda service
+description: Creates an application hosted in AWS Lambda
 category: app/serverless
 type: service/aws-lambda
 appCategories: []

--- a/app.tf
+++ b/app.tf
@@ -1,4 +1,3 @@
-
 data "ns_app_env" "this" {
   stack_id = data.ns_workspace.this.stack_id
   app_id   = data.ns_workspace.this.block_id
@@ -16,7 +15,7 @@ locals {
     function_name     = local.resource_name
     role_name         = aws_iam_role.executor.name
     role_arn          = aws_iam_role.executor.arn
-    security_group_id = try(aws_security_group.this[0].id, "")
+    security_group_id = aws_security_group.this.id
     log_group_name    = module.logs.name
   })
 }

--- a/aws.tf
+++ b/aws.tf
@@ -1,2 +1,1 @@
-provider "aws" {}
 data "aws_region" "this" {}

--- a/lambda.tf
+++ b/lambda.tf
@@ -16,13 +16,9 @@ resource "aws_lambda_function" "this" {
   s3_bucket     = aws_s3_bucket.artifacts.bucket
   s3_key        = local.has_artifact ? local.artifact_key : aws_s3_bucket_object.placeholder.key
 
-  dynamic "vpc_config" {
-    for_each = local.vpc_configs
-
-    content {
-      security_group_ids = vpc_config.value["security_group_ids"]
-      subnet_ids         = vpc_config.value["subnet_ids"]
-    }
+  vpc_config {
+    security_group_ids = [aws_security_group.this.id]
+    subnet_ids         = local.private_subnet_ids
   }
 
   environment {

--- a/lambda.tf
+++ b/lambda.tf
@@ -14,7 +14,7 @@ resource "aws_lambda_function" "this" {
   timeout       = var.service_timeout
   tags          = local.tags
   s3_bucket     = aws_s3_bucket.artifacts.bucket
-  s3_key        = local.has_artifact ? local.artifact_key : aws_s3_bucket_object.placeholder.key
+  s3_key        = local.has_artifact ? local.artifact_key : aws_s3_object.placeholder.key
 
   vpc_config {
     security_group_ids = [aws_security_group.this.id]

--- a/network.tf
+++ b/network.tf
@@ -1,0 +1,9 @@
+data "ns_connection" "network" {
+  name = "network"
+  type = "network/aws"
+}
+
+locals {
+  vpc_id             = data.ns_connection.network.outputs.vpc_id
+  private_subnet_ids = data.ns_connection.network.outputs.private_subnet_ids
+}

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -13,7 +13,7 @@ resource "random_string" "resource_suffix" {
   length  = 5
   lower   = true
   upper   = false
-  number  = false
+  numeric = false
   special = false
 }
 

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -22,19 +22,3 @@ locals {
   block_name    = data.ns_workspace.this.block_name
   resource_name = "${data.ns_workspace.this.block_ref}-${random_string.resource_suffix.result}"
 }
-
-data "ns_connection" "network" {
-  name     = "network"
-  type     = "network/aws"
-  optional = true
-}
-
-locals {
-  has_network = try(length(data.ns_connection.network.outputs.private_subnet_ids), 0) > 0
-  subnet_ids  = try(data.ns_connection.network.outputs.private_subnet_ids, [])
-
-  vpc_configs = local.has_network ? [{
-    subnet_ids         = local.subnet_ids
-    security_group_ids = aws_security_group.this.*.id
-  }] : []
-}

--- a/role.tf
+++ b/role.tf
@@ -24,8 +24,6 @@ resource "aws_iam_role_policy_attachment" "executor_basic" {
 resource "aws_iam_role_policy_attachment" "executor_vpc" {
   role       = aws_iam_role.executor.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
-
-  count = local.has_network ? 1 : 0
 }
 
 resource "aws_iam_role_policy" "executor" {

--- a/security-group.tf
+++ b/security-group.tf
@@ -1,18 +1,16 @@
 resource "aws_security_group" "this" {
-  name   = local.resource_name
-  vpc_id = data.ns_connection.network.outputs.vpc_id
-  tags   = merge(local.tags, { Name = local.resource_name })
-
-  count = local.has_network ? 1 : 0
+  name        = local.resource_name
+  vpc_id      = local.vpc_id
+  tags        = merge(local.tags, { Name = local.resource_name })
+  description = "Managed by Terraform"
 }
 
 resource "aws_security_group_rule" "this-https-to-world" {
-  security_group_id = aws_security_group.this[count.index].id
+  description       = "Allow service to communicate with world over HTTPS"
+  security_group_id = aws_security_group.this.id
   type              = "egress"
   protocol          = "tcp"
   from_port         = 443
   to_port           = 443
   cidr_blocks       = ["0.0.0.0/0"]
-
-  count = local.has_network ? 1 : 0
 }


### PR DESCRIPTION
A customer hit an issue where they attached a postgres capability to a lambda that was configured with default settings.
By default, lambda is configured to run without a VPC.
This resulted in an error trying to create security group rules between the non-VPC lambda and the postgres security group.

This module now requires a network to properly operate.