### PR TITLE
Injecting env vars and secret ids from capabilities

### DIFF
--- a/app.tf
+++ b/app.tf
@@ -11,8 +11,11 @@ locals {
 locals {
   app_metadata = tomap({
     // Inject app metadata into capabilities here (e.g. security_group_name, role_name)
-    function_arn      = aws_lambda_function.this.arn
-    function_name     = local.resource_name
+    function_name = local.resource_name
+    // We can't use aws_lambda_function.this.arn because it will create a cycle lambda => env => capabilities => lambda
+    // NOTE: This *may* introduce a race condition for newly-launched lambdas
+    //    e.g. api gateway capability adds an `aws_lambda_permission` before the lambda exists
+    function_arn      = "arn:aws:lambda:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:function:${local.resource_name}"
     role_name         = aws_iam_role.executor.name
     role_arn          = aws_iam_role.executor.arn
     security_group_id = aws_security_group.this.id

--- a/aws.tf
+++ b/aws.tf
@@ -1,1 +1,2 @@
 data "aws_region" "this" {}
+data "aws_caller_identity" "this" {}

--- a/env.tf
+++ b/env.tf
@@ -1,0 +1,7 @@
+locals {
+  standard_env_vars = tomap({
+    NULLSTONE_ENV = data.ns_workspace.this.env_name
+  })
+  cap_env_vars = { for item in try(local.capabilities.env, []) : item.name => item.value }
+  env_vars     = merge(local.cap_env_vars, local.app_secret_ids, var.service_env_vars, local.standard_env_vars)
+}

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,10 +1,3 @@
-locals {
-  standard_env_vars = tomap({
-    NULLSTONE_ENV = data.ns_workspace.this.env_name
-  })
-  env_vars = { for k, v in merge(local.standard_env_vars, var.service_env_vars) : k => v }
-}
-
 resource "aws_lambda_function" "this" {
   function_name = local.resource_name
   handler       = var.service_handler

--- a/secrets.tf
+++ b/secrets.tf
@@ -9,7 +9,7 @@ locals {
 
   // Since lambda does not have secret injection, we are going to add a list of env vars mapping the secret ids
   // e.g. POSTGRES_URL => POSTGRES_URL_SECRET_ID = <secret-id>
-  app_secret_ids = { for key in local.secret_keys : key => aws_secretsmanager_secret.app_secret[key].id }
+  app_secret_ids = { for key in local.secret_keys : "${key}_SECRET_ID" => aws_secretsmanager_secret.app_secret[key].id }
 }
 
 resource "aws_secretsmanager_secret" "app_secret" {


### PR DESCRIPTION
This updates the lambda function to add env vars and secrets from capabilities.
For secrets, we inject `<SECRET-NAME>_SECRET_ID` env vars since it does not support secrets injection.