### PR TITLE
Enable user-created secrets env vars

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,16 @@ It is dangerous to put sensitive information in this variable because they are n
 EOF
 }
 
+variable "service_secrets" {
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+  description = <<EOF
+The sensitive environment variables to inject into the service.
+These are typically used to configure a service per environment.
+EOF
+}
+
 variable "service_timeout" {
   type        = number
   default     = 3


### PR DESCRIPTION
This adds a `service_secrets` sensitive variable.
These secrets are combined with capability secrets to inject into app via secrets manager.