### PR TITLE
F1945 lambda secret refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 0.12.21 (Feb 06, 2024)
+# 0.12.25 (Jul 18, 2024)
+* Added the ability to reference existing secrets using interpolation.
+* e.g. "{{ secret(arn-of-existing-secret) }}"
+
+* # 0.12.21 (Feb 06, 2024)
 * Added support for metrics in capabilities.
 
 # 0.12.20 (Feb 01, 2024)

--- a/app.tf
+++ b/app.tf
@@ -13,7 +13,7 @@ locals {
   invoke_arn = "arn:aws:apigateway:${data.aws_region.this.name}:lambda:path/2015-03-31/functions/${local.lambda_arn}/invocations"
   app_metadata = tomap({
     // Inject app metadata into capabilities here (e.g. security_group_id, role_name)
-    function_name     = local.resource_name
+    function_name = local.resource_name
     // We can't use aws_lambda_function.this.arn because it will create a cycle lambda => env => capabilities => lambda
     // NOTE: This *may* introduce a race condition for newly-launched lambdas
     //    e.g. api gateway capability adds an `aws_lambda_permission` before the lambda exists

--- a/env_vars.tf
+++ b/env_vars.tf
@@ -44,11 +44,11 @@ data "ns_secret_keys" "this" {
 }
 
 locals {
-  secret_keys  = data.ns_secret_keys.this.secret_keys
-  all_secrets  = data.ns_env_variables.this.secrets
+  secret_keys          = data.ns_secret_keys.this.secret_keys
+  all_secrets          = data.ns_env_variables.this.secrets
   existing_secret_refs = data.ns_env_variables.this.secret_refs // TEST = arn:aws:secretsmanager:us-east-1:522657839841:secret:hello-world/SECRET_KEY_BASE/20240704174816540100000006-WgCRyY
-  existing_secret_ids = { for key, ref in data.ns_env_variables.this.secret_refs : key => data.aws_secretsmanager_secret.existing_secret[key].id }
-  all_env_vars = merge(data.ns_env_variables.this.env_variables, local.app_secret_ids, local.existing_secret_ids)
+  existing_secret_ids  = { for key, ref in data.ns_env_variables.this.secret_refs : key => data.aws_secretsmanager_secret.existing_secret[key].id }
+  all_env_vars         = merge(data.ns_env_variables.this.env_variables, local.app_secret_ids, local.existing_secret_ids)
 }
 
 // existing secrets are referenced by arn

--- a/env_vars.tf
+++ b/env_vars.tf
@@ -46,16 +46,6 @@ data "ns_secret_keys" "this" {
 locals {
   secret_keys          = data.ns_secret_keys.this.secret_keys
   all_secrets          = data.ns_env_variables.this.secrets
-  existing_secret_refs = data.ns_env_variables.this.secret_refs // TEST = arn:aws:secretsmanager:us-east-1:522657839841:secret:hello-world/SECRET_KEY_BASE/20240704174816540100000006-WgCRyY
-  existing_secret_ids  = { for key, ref in data.ns_env_variables.this.secret_refs : key => data.aws_secretsmanager_secret.existing_secret[key].id }
-  all_env_vars         = merge(data.ns_env_variables.this.env_variables, local.app_secret_ids, local.existing_secret_ids)
-}
-
-// existing secrets are referenced by arn
-// in order to stay consistent with other secrets, we need to convert the arn to id
-// this is used above to convert the map of env variables that map to secret(arn) to id
-data "aws_secretsmanager_secret" "existing_secret" {
-  for_each = local.existing_secret_refs
-
-  arn = each.value
+  existing_secret_refs = data.ns_env_variables.this.secret_refs
+  all_env_vars         = merge(data.ns_env_variables.this.env_variables, local.app_secret_ids, local.existing_secret_refs)
 }

--- a/role.tf
+++ b/role.tf
@@ -33,8 +33,10 @@ resource "aws_iam_role_policy" "executor" {
 
 locals {
   // These are used to generate an IAM policy statement to allow the app to read the secrets
+  existing_arns              = values(local.existing_secret_refs)
   secret_arns                = [for as in aws_secretsmanager_secret.app_secret : as.arn]
-  secret_statement_resources = length(local.secret_arns) > 0 ? [local.secret_arns] : []
+  all_arns                   = concat(local.secret_arns, local.existing_arns)
+  secret_statement_resources = length(local.all_arns) > 0 ? [local.all_arns] : []
 }
 
 data "aws_iam_policy_document" "executor" {

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,8 +1,7 @@
 locals {
   // Since lambda does not have secret injection, we are going to add a list of env vars mapping the secret ids
   // e.g. POSTGRES_URL => POSTGRES_URL_SECRET_ID = <secret-id>
-  app_secret_ids  = { for key in local.secret_keys : "${key}_SECRET_ID" => aws_secretsmanager_secret.app_secret[key].id }
-  app_secret_arns = [for key in local.secret_keys : aws_secretsmanager_secret.app_secret[key].arn]
+  app_secret_ids = { for key in local.secret_keys : "${key}_SECRET_ID" => aws_secretsmanager_secret.app_secret[key].id }
 }
 
 resource "aws_secretsmanager_secret" "app_secret" {
@@ -19,39 +18,4 @@ resource "aws_secretsmanager_secret_version" "app_secret" {
 
   secret_id     = aws_secretsmanager_secret.app_secret[each.value].id
   secret_string = local.all_secrets[each.value]
-}
-
-
-
-locals {
-  existing_arns = values(local.existing_secret_refs)
-  all_arns = concat(local.app_secret_arns, local.existing_arns)
-  secret_statement_resources = length(local.all_arns) > 0 ? [local.all_arns] : []
-}
-
-resource "aws_iam_role_policy_attachment" "lambda-secrets" {
-  role       = aws_iam_role.executor.name
-  policy_arn = aws_iam_policy.secrets.arn
-}
-
-resource "aws_iam_policy" "secrets" {
-  name   = local.resource_name
-  policy = data.aws_iam_policy_document.secrets.json
-}
-
-data "aws_iam_policy_document" "secrets" {
-  dynamic "statement" {
-    for_each = local.secret_statement_resources
-
-    content {
-      sid       = "AllowReadSecrets"
-      effect    = "Allow"
-      resources = statement.value
-  
-      actions = [
-        "secretsmanager:GetSecretValue",
-        "kms:Decrypt"
-      ]
-    }
-  }
 }


### PR DESCRIPTION
This PR adds support for references to existing secrets to this module.

If a user sets an env var to the value "{{ secret(arn) }}", we were just discarding this env var. With this PR, the env var will now be included and have a value set to the arn passed in. We also add permissions for the app to be able to the secret from secrets manager.